### PR TITLE
remove smallvec dep (requires alloc crate) and use const generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 exclude = [".github"]
 
 [dependencies]
-smallvec = "1.5"
+heapless = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This project is under development and the current API is subjective to change. P
 ```
 use rhythms::Pattern;
 
-let pattern = Pattern::new(4, 2, 0);
+// Initialize the Pattern struct with a maximum of 64 steps
+let pattern = Pattern::<64>::new(4, 2, 0);
 assert_eq!([true, false, true, false], pattern.as_slice());
 
 // or


### PR DESCRIPTION
- Remove `smallvec` dependency as it requires `alloc`: https://github.com/servo/rust-smallvec/blob/v1/src/lib.rs#L105 making this crate more embedded friendly
- Use const generics to allow user customizable maximum steps